### PR TITLE
Timetable display - Horizontal scrolling and dark theme color updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,8 +55,9 @@
     "clsx": "^2.1.1"
   },
   "dependencies": {
+    "dayjs": "^1.11.13",
     "decode-formdata": "^0.8.0",
-    "valibot": "^1.0.0-beta.9",
-    "dayjs": "^1.11.13"
+    "react-sticky-el": "^2.1.1",
+    "valibot": "^1.0.0-beta.9"
   }
 }

--- a/src/routes/timetable/dummyTimetable.ts
+++ b/src/routes/timetable/dummyTimetable.ts
@@ -202,6 +202,264 @@ export const data = {
     ]
 }
 
+
+export const data2 = {
+  subjects: [
+      {
+        name: {
+          shortName: "KČR",
+          fullName: "Komunikacija Človek Računalnik"
+        },
+        color: "rgba(205, 201, 233, 0.7)",
+        activities: [
+          {
+            activityType: "P",
+            location: "P01",
+            teacher: ["Luka Čehovin Zajc", "Ciril Bohak"],
+            day: "TOR",
+            hourStart: 13,
+            hourEnd: 16
+          },
+          {
+              activityType: "LV",
+              location: "PR06",
+              teacher: ["Luka Čehovin Zajc"],
+              day: "ČET",
+              hourStart: 15,
+              hourEnd: 17
+          },
+          {
+              activityType: "LV",
+              location: "PR17",
+              teacher: ["Luka Čehovin Zajc"],
+              day: "PET",
+              hourStart: 15,
+              hourEnd: 17
+          },
+          {
+              activityType: "LV",
+              location: "PR08",
+              teacher: ["Ciril Bohak"],
+              day: "PON",
+              hourStart: 7,
+              hourEnd: 9
+          },
+          {
+              activityType: "LV",
+              location: "PR06",
+              teacher: ["Ciril Bohak"],
+              day: "PON",
+              hourStart: 13,
+              hourEnd: 15
+          },
+          {
+              activityType: "LV",
+              location: "PR11",
+              teacher: ["Luka Čehovin Zajc"],
+              day: "TOR",
+              hourStart: 9,
+              hourEnd: 11
+          },
+      ]
+      },
+      {
+          name: {
+            shortName: "P",
+            fullName: "Funkcijsko Programiranje"
+          },
+          color: "rgba(165, 233, 221, 0.7)",
+          activities: [
+            {
+              activityType: "P",
+              location: "P01",
+              teacher: ["Zoran Bosnić"],
+              day: "SRE",
+              hourStart: 7,
+              hourEnd: 10
+            },
+            {
+              activityType: "LV",
+              location: "PR06",
+              teacher: ["Klemen Klanjšček"],
+              day: "TOR",
+              hourStart: 9,
+              hourEnd: 11
+            },
+            {
+                activityType: "LV",
+                location: "PR08",
+                teacher: ["Klemen Klanjšček"],
+                day: "ČET",
+                hourStart: 15,
+                hourEnd: 17
+            },
+            {
+                activityType: "LV",
+                location: "PR07",
+                teacher: ["Klemen Klanjšček"],
+                day: "ČET",
+                hourStart: 17,
+                hourEnd: 19
+            },
+            {
+                activityType: "LV",
+                location: "PR11",
+                teacher: ["Klemen Klanjšček"],
+                day: "PET",
+                hourStart: 8,
+                hourEnd: 10
+            },
+            {
+                activityType: "LV",
+                location: "PR08",
+                teacher: ["Klemen Klanjšček"],
+                day: "PET",
+                hourStart: 10,
+                hourEnd: 12
+            },
+        ]
+      },
+      {
+          name: {
+            shortName: "IVZ",
+            fullName: "Informacijska Varnost in Zasebnost"
+          },
+          color: "rgba(255, 255, 200, 0.7)",
+          activities: [
+            {
+              activityType: "P",
+              location: "P04",
+              teacher: ["Denis Trček"],
+              day: "PET",
+              hourStart: 13,
+              hourEnd: 16
+            },
+            {
+              activityType: "LV",
+              location: "PR16",
+              teacher: ["David Jelenc"],
+              day: "TOR",
+              hourStart: 11,
+              hourEnd: 13
+            },
+            {
+                activityType: "LV",
+                location: "PR10",
+                teacher: ["David Jelenc"],
+                day: "TOR",
+                hourStart: 15,
+                hourEnd: 17
+            },
+            {
+                activityType: "LV",
+                location: "PR15",
+                teacher: ["David Jelenc"],
+                day: "PET",
+                hourStart: 11,
+                hourEnd: 13
+            }
+        ]
+      },
+      {
+          name: {
+              shortName: "TEST",
+              fullName: "Testiranje"
+            },
+            color: "rgba(255, 255, 56, 0.7)",
+            activities: [
+              {
+                activityType: "AV",
+                location: "P04",
+                teacher: ["Prosto prosto"],
+                day: "TOR",
+                hourStart: 13,
+                hourEnd: 15
+              },
+              {
+                  activityType: "AV",
+                  location: "P05",
+                  teacher: ["Prosto prosto"],
+                  day: "TOR",
+                  hourStart: 14,
+                  hourEnd: 16
+              },
+              {
+                  activityType: "AV",
+                  location: "P07",
+                  teacher: ["Prosto prosto"],
+                  day: "TOR",
+                  hourStart: 15,
+                  hourEnd: 17
+              },
+              {
+                  activityType: "AV",
+                  location: "P08",
+                  teacher: ["Prosto prosto"],
+                  day: "TOR",
+                  hourStart: 15,
+                  hourEnd: 17
+              },
+              {
+                activityType: "AV",
+                location: "P08",
+                teacher: ["Prosto prosto"],
+                day: "TOR",
+                hourStart: 15,
+                hourEnd: 17
+              },
+              {
+                activityType: "AV",
+                location: "P08",
+                teacher: ["Prosto prosto"],
+                day: "SRE",
+                hourStart: 15,
+                hourEnd: 17
+              },
+              {
+                activityType: "AV",
+                location: "P08",
+                teacher: ["Prosto prosto"],
+                day: "SRE",
+                hourStart: 15,
+                hourEnd: 17
+              },
+              {
+                activityType: "AV",
+                location: "P08",
+                teacher: ["Prosto prosto"],
+                day: "SRE",
+                hourStart: 15,
+                hourEnd: 17
+              },
+              {
+                activityType: "AV",
+                location: "P08",
+                teacher: ["Prosto prosto"],
+                day: "PON",
+                hourStart: 14,
+                hourEnd: 16
+              },
+              {
+                activityType: "AV",
+                location: "P08",
+                teacher: ["Prosto prosto"],
+                day: "PON",
+                hourStart: 14,
+                hourEnd: 16
+              },
+              {
+                activityType: "AV",
+                location: "P08",
+                teacher: ["Prosto prosto"],
+                day: "PON",
+                hourStart: 14,
+                hourEnd: 16
+              },
+          ]
+      }
+  ]
+}
+
 function transformTimes(data: any): Timetable {
     // Helper function to get the base date of the week for a specific day
     function getBaseDate(day: string, weekStart: Date): Date {
@@ -259,4 +517,4 @@ function transformTimes(data: any): Timetable {
     };
   }
 
-export const dummyTimetable = transformTimes(data);
+export const dummyTimetable = transformTimes(data2);

--- a/src/routes/timetable/dummyTimetable.ts
+++ b/src/routes/timetable/dummyTimetable.ts
@@ -231,7 +231,7 @@ export const data2 = {
           {
               activityType: "LV",
               location: "PR17",
-              teacher: ["Luka Čehovin Zajc"],
+              teacher: ["Luka Čehovin Zajc", "test1", "test2"],
               day: "PET",
               hourStart: 15,
               hourEnd: 17

--- a/src/routes/timetable/index.tsx
+++ b/src/routes/timetable/index.tsx
@@ -61,7 +61,7 @@ const TimetableColumn = component$((props: timetableColumnProps) => {
                                 class="flex flex-col w-full h-full dark:text-black /* white does not provide enough contrast */ rounded-lg p-1 z-10 m-1 overflow-hidden text-pretty"
                                 style={{
                                   backgroundColor: `${activity.color}`,
-                                  height: `${dayjs(activity.dateTo).diff(dayjs(activity.dateFrom), "hour") * 3.7}rem`,
+                                  height: `${dayjs(activity?.dateTo).diff(dayjs(activity?.dateFrom), "hour") * 4 - 0.6}rem`,
                                 }}
                               >
                                 <div class="font-bold mb-1">

--- a/src/routes/timetable/index.tsx
+++ b/src/routes/timetable/index.tsx
@@ -39,7 +39,7 @@ const TimetableColumn = component$((props: timetableColumnProps) => {
         const groupHours = Array.from({ length: grouping.end.getHours() - grouping.start.getHours()}, (_, i) => i + grouping.start.getHours());
         const maxActivityCol = grouping.activities.reduce((acc, el) => (!acc || el.col > acc) ? el.col : acc, 0);
         return (
-          <div key={`${day}-${grouping.start}-${grouping.end}`} class="flex flex-row ">
+          <div key={`${day}-${grouping.start}-${grouping.end}`} class="flex flex-row">
             {
               Array.from({length: maxActivityCol + 1}, (_, i) => i).map((i) => {
                 return (
@@ -54,11 +54,11 @@ const TimetableColumn = component$((props: timetableColumnProps) => {
                             ?
                             <div
                               key={`${day}-${hour}`}
-                              class="flex flex-row w-full h-16 border-b border-gray-300 relative"
+                              class="flex flex-row w-full min-w-full h-16 border-b border-gray-300 relative"
                             >
                               <div
                                 key={activity.dateFrom.toString()}
-                                class="flex flex-col w-full h-full dark:text-black /* white does not provide enough contrast */ rounded-lg p-1 z-10 m-1"
+                                class="flex flex-col w-full h-full dark:text-black /* white does not provide enough contrast */ rounded-lg p-1 z-10 m-1 overflow-hidden text-nowrap"
                                 style={{
                                   backgroundColor: `${activity.color}`,
                                   height: `${dayjs(activity.dateTo).diff(dayjs(activity.dateFrom), "hour") * 3.7}rem`,
@@ -107,9 +107,9 @@ const DesktopTimetable = component$((props: timetableProps) => {
   const hours = Array.from({ length: 15 }, (_, i) => i + 7);
 
   return (
-    <div class="flex flex-row shadow-md rounded-lg overflow-auto">
-      <div class="flex flex-col sticky left-0 z-50">
-        <div class="py-4 border-b border-gray-300">
+    <div class="flex flex-row shadow-md rounded-lg w-full overflow-x-scroll">
+      <div class="flex flex-col sticky left-0 z-50 bg-white dark:bg-black">
+        <div class="py-4 border-b border-gray-800">
           <br />
         </div>
         {hours.map((hour) => (
@@ -124,7 +124,7 @@ const DesktopTimetable = component$((props: timetableProps) => {
       {days.map((day, index) => {
         const dayGroupings = props.daysData[index];
         return (
-          <div key={day} class="flex flex-col min-w-[20%] border-l border-gray-800">
+          <div key={day} class="flex flex-col w-[20%] min-w-max border-l border-gray-800">
             <div class="flex flex-row py-4 font-bold text-center border-b border-gray-600">
               <div class="flex flex-col w-full">{day}</div>
             </div>
@@ -156,8 +156,8 @@ const MobileTimetable = component$((props: timetableProps) => {
   return (
     <>
       <div class="flex flex-row">
-        <div class="flex flex-col">
-          <div class="py-4 border-y border-gray-300">
+        <div class="flex flex-col sticky left-0 z-50 bg-white dark:bg-black">
+          <div class="py-4 border-y border-gray-800">
             <br />
           </div>
           {hours.map((hour) => (
@@ -172,8 +172,8 @@ const MobileTimetable = component$((props: timetableProps) => {
           ))}
         </div>
 
-        <div class="flex flex-col w-full border border-gray-800">
-          <div class="flex flex-row sticky top-0 z-50 font-bold text-center items-center shadow-lg border-b border-gray-600">
+        <div class="flex flex-col w-full border border-gray-800 overflow-x-scroll">
+          <div class="flex flex-row sticky left-0 top-0 z-50 font-bold text-center items-center shadow-lg border-b border-gray-600 bg-white dark:bg-black">
             {daysShort.map((day, index) => (
               <div
                 key={index}
@@ -184,6 +184,7 @@ const MobileTimetable = component$((props: timetableProps) => {
                 }`}
                 onClick$={() => (selectedDaySignal.value = days[index])}
               >
+
                 <span>{day}</span>
 
                 <div
@@ -196,7 +197,7 @@ const MobileTimetable = component$((props: timetableProps) => {
           </div>
 
           <div class="flex flex-row w-full">
-            <div class="flex flex-col w-full">
+            <div class="flex flex-col w-full min-w-max">
               <TimetableColumn
                 dayData={props.daysData[days.findIndex((el) => el === selectedDaySignal.value)]}
                 day={selectedDaySignal.value}
@@ -214,10 +215,7 @@ const MobileTimetable = component$((props: timetableProps) => {
 export default component$(() => {
   const startOfWeek = dayjs(new Date()).startOf('week').toDate();
   const endOfWeek = dayjs(new Date()).endOf('week').toDate();
-  
-  // Zacasna funkcija za prikaz
-  // To bo treba itak fetchati iz backenda/karkoli bo ze, teden za tednom.
-  // Druga opcija je da imamo na voljo samo en teden in je dinamicen urnik sporočen pravočasno
+
   function getSelectedWeekTimetable(fullTimetable: Timetable, weekStart: Date, weekEnd: Date): Timetable {
     return {
       subjects: fullTimetable.subjects.map((subject) => {

--- a/src/routes/timetable/index.tsx
+++ b/src/routes/timetable/index.tsx
@@ -109,11 +109,11 @@ const DesktopTimetable = component$((props: timetableProps) => {
   return (
     <div class="flex flex-row shadow-md rounded-lg overflow-auto">
       <div class="flex flex-col sticky left-0 z-50">
-        <div class="py-4 border border-gray-400">
+        <div class="py-4 border-b border-gray-300">
           <br />
         </div>
         {hours.map((hour) => (
-          <div key={hour} class="flex h-16 pl-2 border border-gray-400">
+          <div key={hour} class="flex h-16 pl-2 border-b border-gray-300">
             <div class="text-right">
               {`${dayjs().hour(hour).format("HH")}:00`}
             </div>
@@ -124,7 +124,7 @@ const DesktopTimetable = component$((props: timetableProps) => {
       {days.map((day, index) => {
         const dayGroupings = props.daysData[index];
         return (
-          <div key={day} class="flex flex-col min-w-[20%] border border-gray-800">
+          <div key={day} class="flex flex-col min-w-[20%] border-l border-gray-800">
             <div class="flex flex-row py-4 font-bold text-center border-b border-gray-600">
               <div class="flex flex-col w-full">{day}</div>
             </div>
@@ -157,13 +157,13 @@ const MobileTimetable = component$((props: timetableProps) => {
     <>
       <div class="flex flex-row">
         <div class="flex flex-col">
-          <div class="py-4 border border-gray-400">
+          <div class="py-4 border-y border-gray-300">
             <br />
           </div>
           {hours.map((hour) => (
             <div
               key={hour}
-              class="flex h-16 pl-2 border border-gray-400"
+              class="flex h-16 pl-2 border-b border-gray-300"
             >
               <div class="text-right">
                 {`${dayjs().hour(hour).format('HH')}:00`}

--- a/src/routes/timetable/index.tsx
+++ b/src/routes/timetable/index.tsx
@@ -58,7 +58,7 @@ const TimetableColumn = component$((props: timetableColumnProps) => {
                             >
                               <div
                                 key={activity.dateFrom.toString()}
-                                class="flex flex-col w-full h-full dark:text-black /* white does not provide enough contrast */ rounded-lg p-1 z-10 m-1 overflow-hidden text-nowrap"
+                                class="flex flex-col w-full h-full dark:text-black /* white does not provide enough contrast */ rounded-lg p-1 z-10 m-1 overflow-hidden text-pretty"
                                 style={{
                                   backgroundColor: `${activity.color}`,
                                   height: `${dayjs(activity.dateTo).diff(dayjs(activity.dateFrom), "hour") * 3.7}rem`,

--- a/src/routes/timetable/index.tsx
+++ b/src/routes/timetable/index.tsx
@@ -1,9 +1,14 @@
-import { component$, useSignal, useContext } from '@builder.io/qwik';
+import { component$, useSignal, useContext, useVisibleTask$ } from '@builder.io/qwik';
+import { qwikify$ } from '@builder.io/qwik-react';
 import type { Timetable, Activity } from '../../models/Timetable'
 import { dummyTimetable } from './dummyTimetable'; // Temporary data
 import dayjs from "../../lib/dayjsConfig"
 import { type Dayjs } from 'dayjs';
 import { Platform } from '~/lib/state/platform';
+import Sticky from 'react-sticky-el';
+import { Mode } from '~/lib/state/mode';
+
+const QSticky = qwikify$(Sticky)
 
 type timetableProps = {
   daysData: activityGroup[][],
@@ -48,45 +53,42 @@ const TimetableColumn = component$((props: timetableColumnProps) => {
                       groupHours.map((hour) => {
                         const activity = grouping.activities.find((activity) => (activity.dateFrom.getHours() == hour && activity.col == i));
                         return (
-                          <>
+                          <div key={`${day}-${hour}-${i}`}>
                           {
                             activity
                             ?
                             <div
-                              key={`${day}-${hour}`}
-                              class="flex flex-row w-full min-w-full h-16 border-b border-gray-300 relative"
+                              class="flex flex-row w-full h-16 border-b border-gray-300 dark:border-gray-600 relative"
                             >
                               <div
-                                key={activity.dateFrom.toString()}
-                                class="flex flex-col w-full h-full dark:text-black /* white does not provide enough contrast */ rounded-lg p-1 z-10 m-1 overflow-hidden text-pretty"
+                                class="flex flex-col w-full min-w-max dark:text-black /* white does not provide enough contrast */ rounded-lg p-1 z-10 m-1 break-words overflow-hidden text-balance"
                                 style={{
                                   backgroundColor: `${activity.color}`,
-                                  height: `${dayjs(activity?.dateTo).diff(dayjs(activity?.dateFrom), "hour") * 4 - 0.6}rem`,
+                                  height: `${dayjs(activity.dateTo).diff(dayjs(activity.dateFrom), "hour") * 4 - 0.6}rem`,
                                 }}
                               >
-                                <div class="font-bold mb-1">
+                                <div class="text-base font-bold mb-1">
                                   {activity.shortName}_{activity.activityType}
                                 </div>
-                                <div class="text-sm italic mb-2">
+                                <div class="text-sm italic mb-1">
                                   {activity.teacher.join(", ")}
                                 </div>
-                                <div class="text-sm font-semibold">
+                                <div class="text-base font-semibold">
                                   {activity.location}
                                 </div>
                                 
-                                <div class="text-sm text-gray-500 mt-auto">
+                                <div class="text-sm text-gray-500 dark:text-black mt-auto">
                                   {dayjs(activity.dateFrom).format("HH:mm")} - {dayjs(activity.dateTo).format("HH:mm")}
                                 </div>
                               </div>
                             </div>
                             :
                             <div
-                              key={`${day}-${hour}`}
-                              class="flex flex-row w-full h-16 border-b border-gray-300 relative"
+                              class="flex flex-row w-full h-16 border-b border-gray-300 dark:border-gray-600 relative"
                             >
                             </div>
                           }
-                          </>
+                          </div>
                         );
                       })
                     }
@@ -106,14 +108,17 @@ const DesktopTimetable = component$((props: timetableProps) => {
   const days = props.possibleDays;
   const hours = Array.from({ length: 15 }, (_, i) => i + 7);
 
+  // eslint-disable-next-line qwik/no-use-visible-task
+  useVisibleTask$(() => document.body.classList.add("overflow-x-scroll"))
+
   return (
-    <div class="flex flex-row shadow-md rounded-lg w-full overflow-x-scroll">
+    <div class="flex flex-row w-full">
       <div class="flex flex-col sticky left-0 z-50 bg-white dark:bg-black">
-        <div class="py-4 border-b border-gray-800">
+        <div class="py-4 border-b border-gray-800 dark:border-gray-200">
           <br />
         </div>
         {hours.map((hour) => (
-          <div key={hour} class="flex h-16 pl-2 border-b border-gray-300">
+          <div key={hour} class="flex h-16 pl-2 border-b border-gray-300 dark:border-gray-600">
             <div class="text-right">
               {`${dayjs().hour(hour).format("HH")}:00`}
             </div>
@@ -124,8 +129,8 @@ const DesktopTimetable = component$((props: timetableProps) => {
       {days.map((day, index) => {
         const dayGroupings = props.daysData[index];
         return (
-          <div key={day} class="flex flex-col w-[20%] min-w-max border-l border-gray-800">
-            <div class="flex flex-row py-4 font-bold text-center border-b border-gray-600">
+          <div key={day} class="flex flex-col w-[20%] min-w-max border-l border-gray-800 dark:border-gray-200">
+            <div class="flex flex-row py-4 font-bold text-center border-b border-gray-600 dark:border-gray-200">
               <div class="flex flex-col w-full">{day}</div>
             </div>
 
@@ -147,23 +152,28 @@ const DesktopTimetable = component$((props: timetableProps) => {
 
 
 const MobileTimetable = component$((props: timetableProps) => {
-  const selectedDaySignal = useSignal("Torek"); // Signal for the currently selected day
-  
+  let todayDayIndex = dayjs().day()
+  // if Sunday (0) or Saturday (6), then set it to be Monday (1), since most people checking over the weekend will probably want to look at Monday.
+  if(todayDayIndex == 0 || todayDayIndex == 6)
+    todayDayIndex = 1 
+  const selectedDaySignal = useSignal(props.possibleDays[todayDayIndex - 1]);
   const days = props.possibleDays;
   const daysShort = ["PON", "TOR", "SRE", "ČET", "PET"];
   const hours = Array.from({ length: 15 }, (_, i) => i + 7);
+  
+  const stickyPositionSignal = useSignal("sticky");
 
   return (
     <>
       <div class="flex flex-row">
         <div class="flex flex-col sticky left-0 z-50 bg-white dark:bg-black">
-          <div class="py-4 border-y border-gray-800">
+          <div class="py-4 border-y border-gray-800 dark:border-gray-200">
             <br />
           </div>
           {hours.map((hour) => (
             <div
               key={hour}
-              class="flex h-16 pl-2 border-b border-gray-300"
+              class="flex h-16 pl-2 border-b border-gray-300 dark:border-gray-600"
             >
               <div class="text-right">
                 {`${dayjs().hour(hour).format('HH')}:00`}
@@ -172,31 +182,39 @@ const MobileTimetable = component$((props: timetableProps) => {
           ))}
         </div>
 
-        <div class="flex flex-col w-full border border-gray-800 overflow-x-scroll">
-          <div class="flex flex-row sticky left-0 top-0 z-50 font-bold text-center items-center shadow-lg border-b border-gray-600 bg-white dark:bg-black">
-            {daysShort.map((day, index) => (
-              <div
-                key={index}
-                class={`flex flex-col justify-center items-center w-full py-4 cursor-pointer transition-all relative ${
-                  selectedDaySignal.value === days[index]
-                    ? 'font-bold w-1/3'
-                    : 'text-gray-500 w-1/4'
-                }`}
-                onClick$={() => (selectedDaySignal.value = days[index])}
-              >
+        <div class="flex flex-col w-full border border-gray-800 dark:border-gray-200 overflow-x-scroll">
+          <div class="left-0 z-50"
+          style={{
+            position: stickyPositionSignal.value as unknown as undefined
+          }}
+          >
+            <QSticky onFixedToggle$={(isFixed) => (isFixed ? (stickyPositionSignal.value = "relative") : (stickyPositionSignal.value = "sticky"))}>
+              <div class="flex flex-row font-bold text-center items-center shadow-lg border-b border-gray-600 dark:border-gray-200 bg-white dark:bg-black">
+                {daysShort.map((day, index) => (
+                  <div
+                    key={index}
+                    class={`flex flex-col justify-center items-center w-full py-4 cursor-pointer transition-all relative ${
+                      selectedDaySignal.value === days[index]
+                        ? 'font-bold w-1/3'
+                        : 'text-gray-500 w-1/4'
+                    }`}
+                    onClick$={() => (selectedDaySignal.value = days[index])}
+                  >
 
-                <span>{day}</span>
+                    <span>{day}</span>
 
-                <div
-                  class={`absolute bottom-0 left-0 h-1 w-full transition-all duration-300 ${
-                    selectedDaySignal.value === days[index] ? 'bg-primary' : 'bg-transparent'
-                  }`}
-                />
+                    <div
+                      class={`absolute bottom-0 left-0 h-1 w-full transition-all duration-300 ${
+                        selectedDaySignal.value === days[index] ? 'bg-primary' : 'bg-transparent'
+                      }`}
+                    />
+                  </div>
+                ))}
               </div>
-            ))}
+            </QSticky>
           </div>
-
-          <div class="flex flex-row w-full">
+          
+          <div class="flex flex-row w-full min-w-max">
             <div class="flex flex-col w-full min-w-max">
               <TimetableColumn
                 dayData={props.daysData[days.findIndex((el) => el === selectedDaySignal.value)]}
@@ -215,16 +233,93 @@ const MobileTimetable = component$((props: timetableProps) => {
 export default component$(() => {
   const startOfWeek = dayjs(new Date()).startOf('week').toDate();
   const endOfWeek = dayjs(new Date()).endOf('week').toDate();
+  const isDarkMode = useContext(Mode);
+
+  function rgbaToHsv(r: number, g: number, b: number, a = 1) {
+    r /= 255;
+    g /= 255;
+    b /= 255;
+
+    const max = Math.max(r, g, b);
+    const min = Math.min(r, g, b);
+    const delta = max - min;
+
+    let h = 0;
+    let s = 0;
+    const v = max;
+
+    if (delta !== 0) {
+        s = delta / max;
+
+        if (max === r) {
+            h = ((g - b) / delta + (g < b ? 6 : 0)) % 6;
+        } else if (max === g) {
+            h = (b - r) / delta + 2;
+        } else {
+            h = (r - g) / delta + 4;
+        }
+
+        h *= 60;
+    }
+
+    return { h, s, v, a };
+  }
+
+  function hsvToRgba(h: number, s: number, v: number, a = 1) {
+      const c = v * s;
+      const x = c * (1 - Math.abs((h / 60) % 2 - 1));
+      const m = v - c;
+
+      let r = 0, g = 0, b = 0;
+
+      if (h >= 0 && h < 60) {
+          r = c; g = x; b = 0;
+      } else if (h >= 60 && h < 120) {
+          r = x; g = c; b = 0;
+      } else if (h >= 120 && h < 180) {
+          r = 0; g = c; b = x;
+      } else if (h >= 180 && h < 240) {
+          r = 0; g = x; b = c;
+      } else if (h >= 240 && h < 300) {
+          r = x; g = 0; b = c;
+      } else {
+          r = c; g = 0; b = x;
+      }
+
+      r = Math.round((r + m) * 255);
+      g = Math.round((g + m) * 255);
+      b = Math.round((b + m) * 255);
+
+      return `rgba(${r}, ${g}, ${b}, ${a})`;
+  }
+
+  function changeActivitiesColorForDarkMode(isDarkMode: boolean, timetable: Timetable): Timetable {
+    if(!isDarkMode)
+      return timetable;
+    
+    for(const subject of timetable.subjects) {
+      const subjectColorComponents: number[] = subject.color.split("(")[1].split(")")[0].split(",").map(Number);
+      const [r, g, b, a] = subjectColorComponents;
+
+      const { h, s, v } = rgbaToHsv(r, g, b, a);
+
+      const adjustedV = Math.min(1, v * 1.2); 
+      const adjustedS = Math.min(1, s * 1.5);
+
+      subject.color = hsvToRgba(h, adjustedS, adjustedV, a);
+    }
+    return timetable;
+  }
 
   function getSelectedWeekTimetable(fullTimetable: Timetable, weekStart: Date, weekEnd: Date): Timetable {
     return {
       subjects: fullTimetable.subjects.map((subject) => {
-        const filteredActivities = subject.activities.filter((activity) => {
+        const filteredActivities = subject.activities.filter((activity) => { 
           return (
             activity.dateFrom >= weekStart && activity.dateFrom <= weekEnd
           );
         });
-  
+        
         return {
           ...subject,
           activities: filteredActivities,
@@ -233,7 +328,7 @@ export default component$(() => {
     };
   }
 
-  const timetable = getSelectedWeekTimetable(dummyTimetable, startOfWeek, endOfWeek)
+  const timetable = changeActivitiesColorForDarkMode(isDarkMode.isDarkTheme.value ? true : false, getSelectedWeekTimetable(dummyTimetable, startOfWeek, endOfWeek))
 
   function groupByHourOverlap(day: Dayjs) {
     const groupedActivities: activityGroup[] = [];
@@ -321,6 +416,7 @@ export default component$(() => {
     }
     return groupingPerDay;
   }
+
 
   const dayScheduleGroup = getScheduleGroupingForEachDay(startOfWeek);
   const days = ["Ponedeljek", "Torek", "Sreda", "Četrtek", "Petek"]


### PR DESCRIPTION
Adjusted horizontal scrolling:
- Desktop: Horizontally scroll across all days when content does not fit
- Mobile: Horizontally scroll across the single current day. Should fit at least 3 overlaps at once until horizontal scroll is needed

Mobile sticky day top:
- Should work correctly no matter the horizontal/vertical scroll (always has the same position on top)

Dark theme:
- Adjusted border colors
- Adjusted activity colors. Dark theme has increased saturation/value for greater text legibility