### PR TITLE
Timetable display - minor improvements

### DIFF
--- a/src/components/footer/footer.tsx
+++ b/src/components/footer/footer.tsx
@@ -9,7 +9,7 @@ export default component$(() => {
   const GithubLogo = mode.isDarkTheme.value ? GithubLogoDark : GithubLogoLight;
 
   return (      
-    <footer class="fixed bottom-0 w-full shadow-lg mx-auto px-4 py-4 invisible md:visible">      
+    <footer class="fixed bottom-0 w-full z-20 shadow-lg mx-auto px-4 py-4 invisible md:visible">      
       <div class="flex justify-center items-center text-center text-sm">    
         <div class="flex items-center gap-1 p-2 backdrop-blur-sm w-fit">  
           <span>Made with <span class="text-primary">♥</span> for <a href="https://fri.uni-lj.si/en" target="_blank">FRI</a> © {new Date().getFullYear()}</span>  

--- a/src/components/footer/footer.tsx
+++ b/src/components/footer/footer.tsx
@@ -9,7 +9,7 @@ export default component$(() => {
   const GithubLogo = mode.isDarkTheme.value ? GithubLogoDark : GithubLogoLight;
 
   return (      
-    <footer class="fixed bottom-0 w-full shadow-lg mx-auto px-4 py-4 invisible md:visible">      
+    <footer class="fixed bottom-0 w-full shadow-lg mx-auto px-4 py-4 z-20 invisible md:visible">      
       <div class="flex justify-center items-center text-center text-sm">    
         <div class="flex items-center gap-1 p-2 backdrop-blur-sm w-fit">  
           <span>Made with <span class="text-primary">♥</span> for <a href="https://fri.uni-lj.si/en" target="_blank">FRI</a> © {new Date().getFullYear()}</span>  

--- a/src/components/footer/footer.tsx
+++ b/src/components/footer/footer.tsx
@@ -9,7 +9,7 @@ export default component$(() => {
   const GithubLogo = mode.isDarkTheme.value ? GithubLogoDark : GithubLogoLight;
 
   return (      
-    <footer class="fixed bottom-0 w-full z-20 shadow-lg mx-auto px-4 py-4 invisible md:visible">      
+    <footer class="fixed bottom-0 w-full shadow-lg mx-auto px-4 py-4 invisible md:visible">      
       <div class="flex justify-center items-center text-center text-sm">    
         <div class="flex items-center gap-1 p-2 backdrop-blur-sm w-fit">  
           <span>Made with <span class="text-primary">♥</span> for <a href="https://fri.uni-lj.si/en" target="_blank">FRI</a> © {new Date().getFullYear()}</span>  

--- a/src/routes/timetable/dummyTimetable.ts
+++ b/src/routes/timetable/dummyTimetable.ts
@@ -67,14 +67,14 @@ export const data = {
             },
             color: "rgba(165, 233, 221, 0.7)",
             activities: [
-              /*{
+              {
                 activityType: "P",
                 location: "P01",
                 teacher: ["Zoran Bosnić"],
                 day: "SRE",
                 hourStart: 7,
                 hourEnd: 10
-              },*/
+              },
               {
                 activityType: "LV",
                 location: "PR06",

--- a/src/routes/timetable/dummyTimetable.ts
+++ b/src/routes/timetable/dummyTimetable.ts
@@ -517,4 +517,4 @@ function transformTimes(data: any): Timetable {
     };
   }
 
-export const dummyTimetable = transformTimes(data2);
+export const dummyTimetable = transformTimes(data);

--- a/src/routes/timetable/index.tsx
+++ b/src/routes/timetable/index.tsx
@@ -153,7 +153,7 @@ const DesktopTimetable = component$((props: timetableProps) => {
   useVisibleTask$(() => document.body.classList.add("overflow-x-auto"))
 
   return (
-    <div class="flex flex-row w-full">
+    <div class="flex flex-row w-full border-b border-gray-800 dark:border-gray-200">
       <div class="flex flex-col sticky left-0 z-30 border-r border-gray-800 dark:border-gray-200 bg-white dark:bg-black">
         <div class="py-4 border-b border-gray-800 dark:border-gray-200">
           <br />
@@ -214,7 +214,7 @@ const MobileTimetable = component$((props: timetableProps) => {
 
   return (
     <>
-      <div class="flex flex-row">
+      <div class="flex flex-row border-b border-gray-800 dark:border-gray-200">
         <div class="flex flex-col sticky left-0 z-20 border-r border-gray-800 dark:border-gray-200 bg-white dark:bg-black">
           <div class="py-4 border-y border-gray-800 dark:border-gray-200">
             <br />
@@ -231,7 +231,7 @@ const MobileTimetable = component$((props: timetableProps) => {
           ))}
         </div>
 
-        <div class="flex flex-col w-full border border-l-0 border-gray-800 dark:border-gray-200 overflow-x-auto">
+        <div class="flex flex-col w-full border-t border-r border-gray-800 dark:border-gray-200 overflow-x-auto">
           <div class="left-0 z-20"
           style={{
             position: stickyPositionSignal.value as unknown as undefined

--- a/src/routes/timetable/index.tsx
+++ b/src/routes/timetable/index.tsx
@@ -113,7 +113,7 @@ const DesktopTimetable = component$((props: timetableProps) => {
 
   return (
     <div class="flex flex-row w-full">
-      <div class="flex flex-col sticky left-0 z-20 border-r border-gray-800 dark:border-gray-200 bg-white dark:bg-black">
+      <div class="flex flex-col sticky left-0 z-30 border-r border-gray-800 dark:border-gray-200 bg-white dark:bg-black">
         <div class="py-4 border-b border-gray-800 dark:border-gray-200">
           <br />
         </div>
@@ -131,7 +131,7 @@ const DesktopTimetable = component$((props: timetableProps) => {
         const borderClasses = (index != days.length - 1) ? ` border-r border-gray-800 dark:border-gray-200` : "";
         return (
           <div key={day} class={`flex flex-col w-[20%] min-w-max` + borderClasses}>
-            <div class="flex flex-row py-4 font-bold text-center border-b border-gray-600 dark:border-gray-200">
+            <div class="flex flex-row sticky top-0 z-20 py-4 font-bold text-center border-b border-gray-600 dark:border-gray-200 bg-white dark:bg-black">
               <div class="flex flex-col w-full">{day}</div>
             </div>
 

--- a/src/routes/timetable/index.tsx
+++ b/src/routes/timetable/index.tsx
@@ -174,7 +174,7 @@ const MobileTimetable = component$((props: timetableProps) => {
           {hours.map((hour) => (
             <div
               key={hour}
-              class="flex h-16 pl-2 border-b border-gray-300 dark:border-gray-600"
+              class="flex h-16 px-2 border-b border-gray-300 dark:border-gray-600"
             >
               <div class="text-right">
                 {`${dayjs().hour(hour).format('HH')}:00`}

--- a/src/routes/timetable/index.tsx
+++ b/src/routes/timetable/index.tsx
@@ -91,7 +91,7 @@ const TimetableColumn = component$((props: timetableColumnProps) => {
                               class="flex flex-row w-full h-16 border-b border-gray-300 dark:border-gray-600 relative"
                             >
                               <div
-                                class="flex flex-col w-full min-w-max dark:text-black /* white does not provide enough contrast */ rounded-lg p-1 m-1 break-words text-balance"
+                                class="flex flex-col w-full min-w-max dark:text-black /* white does not provide enough contrast */ rounded-lg z-10 p-1 m-1 break-words text-balance"
                                 style={{
                                   backgroundColor: `${activity.color}`,
                                   height: `${dayjs(activity.dateTo).diff(dayjs(activity.dateFrom), "hour") * 4 - 0.6}rem`,

--- a/src/routes/timetable/index.tsx
+++ b/src/routes/timetable/index.tsx
@@ -1,4 +1,4 @@
-import { component$, useSignal, useContext, useVisibleTask$, useTask$ } from '@builder.io/qwik';
+import { component$, useSignal, useContext, useVisibleTask$} from '@builder.io/qwik';
 import { qwikify$ } from '@builder.io/qwik-react';
 import type { Timetable, Activity } from '../../models/Timetable'
 import { dummyTimetable } from './dummyTimetable'; // Temporary data
@@ -55,7 +55,7 @@ function maxHourOfNonEmptyActivityGroup(activityGroup: activityGroup[], defaultS
 }
 
 function clipFinalActivityHourOfActivityGroup(activityGroup: activityGroup[], clipToHour: number, clipOnlyEmpty: boolean = true) {
-  let finalActivity = activityGroup[activityGroup.length - 1];
+  const finalActivity = activityGroup[activityGroup.length - 1];
   
   if(clipOnlyEmpty && finalActivity.activities.length !== 0) {
     return;
@@ -138,7 +138,7 @@ const DesktopTimetable = component$((props: timetableProps) => {
   const days = props.possibleDays;
   
   const maxHourOfAllDays = props.daysData.reduce((acc, day) => {
-    let maxHourOfDay = maxHourOfNonEmptyActivityGroup(day, props.defaultStartHour);
+    const maxHourOfDay = maxHourOfNonEmptyActivityGroup(day, props.defaultStartHour);
     if (maxHourOfDay > acc) {
       return maxHourOfDay;
     }

--- a/src/routes/timetable/index.tsx
+++ b/src/routes/timetable/index.tsx
@@ -61,7 +61,7 @@ const TimetableColumn = component$((props: timetableColumnProps) => {
                               class="flex flex-row w-full h-16 border-b border-gray-300 dark:border-gray-600 relative"
                             >
                               <div
-                                class="flex flex-col w-full min-w-max dark:text-black /* white does not provide enough contrast */ rounded-lg p-1 z-10 m-1 break-words overflow-hidden text-balance"
+                                class="flex flex-col w-full min-w-max dark:text-black /* white does not provide enough contrast */ rounded-lg p-1 m-1 break-words text-balance"
                                 style={{
                                   backgroundColor: `${activity.color}`,
                                   height: `${dayjs(activity.dateTo).diff(dayjs(activity.dateFrom), "hour") * 4 - 0.6}rem`,
@@ -109,7 +109,7 @@ const DesktopTimetable = component$((props: timetableProps) => {
   const hours = Array.from({ length: 15 }, (_, i) => i + 7);
 
   // eslint-disable-next-line qwik/no-use-visible-task
-  useVisibleTask$(() => document.body.classList.add("overflow-x-scroll"))
+  useVisibleTask$(() => document.body.classList.add("overflow-x-auto"))
 
   return (
     <div class="flex flex-row w-full">
@@ -183,7 +183,7 @@ const MobileTimetable = component$((props: timetableProps) => {
           ))}
         </div>
 
-        <div class="flex flex-col w-full border border-l-0 border-gray-800 dark:border-gray-200 overflow-x-scroll">
+        <div class="flex flex-col w-full border border-l-0 border-gray-800 dark:border-gray-200 overflow-x-auto">
           <div class="left-0 z-20"
           style={{
             position: stickyPositionSignal.value as unknown as undefined

--- a/src/routes/timetable/index.tsx
+++ b/src/routes/timetable/index.tsx
@@ -113,7 +113,7 @@ const DesktopTimetable = component$((props: timetableProps) => {
 
   return (
     <div class="flex flex-row w-full">
-      <div class="flex flex-col sticky left-0 z-50 bg-white dark:bg-black">
+      <div class="flex flex-col sticky left-0 z-20 bg-white dark:bg-black">
         <div class="py-4 border-b border-gray-800 dark:border-gray-200">
           <br />
         </div>
@@ -166,7 +166,7 @@ const MobileTimetable = component$((props: timetableProps) => {
   return (
     <>
       <div class="flex flex-row">
-        <div class="flex flex-col sticky left-0 z-50 bg-white dark:bg-black">
+        <div class="flex flex-col sticky left-0 z-20 bg-white dark:bg-black">
           <div class="py-4 border-y border-gray-800 dark:border-gray-200">
             <br />
           </div>
@@ -183,7 +183,7 @@ const MobileTimetable = component$((props: timetableProps) => {
         </div>
 
         <div class="flex flex-col w-full border border-gray-800 dark:border-gray-200 overflow-x-scroll">
-          <div class="left-0 z-50"
+          <div class="left-0 z-20"
           style={{
             position: stickyPositionSignal.value as unknown as undefined
           }}

--- a/src/routes/timetable/index.tsx
+++ b/src/routes/timetable/index.tsx
@@ -113,12 +113,12 @@ const DesktopTimetable = component$((props: timetableProps) => {
 
   return (
     <div class="flex flex-row w-full">
-      <div class="flex flex-col sticky left-0 z-20 bg-white dark:bg-black">
+      <div class="flex flex-col sticky left-0 z-20 border-r border-gray-800 dark:border-gray-200 bg-white dark:bg-black">
         <div class="py-4 border-b border-gray-800 dark:border-gray-200">
           <br />
         </div>
         {hours.map((hour) => (
-          <div key={hour} class="flex h-16 pl-2 border-b border-gray-300 dark:border-gray-600">
+          <div key={hour} class="flex h-16 px-2 border-b border-gray-300 dark:border-gray-600">
             <div class="text-right">
               {`${dayjs().hour(hour).format("HH")}:00`}
             </div>
@@ -128,8 +128,9 @@ const DesktopTimetable = component$((props: timetableProps) => {
 
       {days.map((day, index) => {
         const dayGroupings = props.daysData[index];
+        const borderClasses = (index != days.length - 1) ? ` border-r border-gray-800 dark:border-gray-200` : "";
         return (
-          <div key={day} class="flex flex-col w-[20%] min-w-max border-l border-gray-800 dark:border-gray-200">
+          <div key={day} class={`flex flex-col w-[20%] min-w-max` + borderClasses}>
             <div class="flex flex-row py-4 font-bold text-center border-b border-gray-600 dark:border-gray-200">
               <div class="flex flex-col w-full">{day}</div>
             </div>
@@ -166,7 +167,7 @@ const MobileTimetable = component$((props: timetableProps) => {
   return (
     <>
       <div class="flex flex-row">
-        <div class="flex flex-col sticky left-0 z-20 bg-white dark:bg-black">
+        <div class="flex flex-col sticky left-0 z-20 border-r border-gray-800 dark:border-gray-200 bg-white dark:bg-black">
           <div class="py-4 border-y border-gray-800 dark:border-gray-200">
             <br />
           </div>
@@ -182,7 +183,7 @@ const MobileTimetable = component$((props: timetableProps) => {
           ))}
         </div>
 
-        <div class="flex flex-col w-full border border-gray-800 dark:border-gray-200 overflow-x-scroll">
+        <div class="flex flex-col w-full border border-l-0 border-gray-800 dark:border-gray-200 overflow-x-scroll">
           <div class="left-0 z-20"
           style={{
             position: stickyPositionSignal.value as unknown as undefined


### PR DESCRIPTION
Minor improvements all across
- Correct handling of Z-index
- Borders on sticky elements
- Sticky header on desktop
- Display only the necessary hours on both mobile and desktop
- Slight border adjustments